### PR TITLE
fix(getObject): handle case where `boundaryMatches` is `undefined`

### DIFF
--- a/src/actions/getObjectAction.ts
+++ b/src/actions/getObjectAction.ts
@@ -38,7 +38,7 @@ export const getObjectAction =
       : false
     const boundaryMatches = responseHeaders['content-type'].match(/boundary=([^;]+);/)
     const boundary =
-      isMultipart && boundaryMatches.length > 0 ? Buffer.from(boundaryMatches[1]) : Buffer.from('')
+      isMultipart && boundaryMatches?.[1] ? Buffer.from(boundaryMatches[1]) : Buffer.from('')
     const boundaryPrefix = Buffer.from('--')
 
     const objectParser = new ObjectParser({

--- a/src/actions/getObjectAction.ts
+++ b/src/actions/getObjectAction.ts
@@ -36,7 +36,7 @@ export const getObjectAction =
     const isMultipart = responseHeaders['content-type']
       ? /multipart/.test(responseHeaders['content-type'])
       : false
-    const boundaryMatches = responseHeaders['content-type'].match(/boundary=([^;]+);/)
+    const boundaryMatches = responseHeaders['content-type'].match(/boundary=([^;]+);?/)
     const boundary =
       isMultipart && boundaryMatches?.[1] ? Buffer.from(boundaryMatches[1]) : Buffer.from('')
     const boundaryPrefix = Buffer.from('--')

--- a/src/actions/getObjectAction.ts
+++ b/src/actions/getObjectAction.ts
@@ -34,7 +34,7 @@ export const getObjectAction =
       : null
 
     const isMultipart = responseHeaders['content-type']
-      ? responseHeaders['content-type'].match(/multipart/).length > 0
+      ? /multipart/.test(responseHeaders['content-type'])
       : false
     const boundaryMatches = responseHeaders['content-type'].match(/boundary=([^;]+);/)
     const boundary =

--- a/src/types/RetsObject.ts
+++ b/src/types/RetsObject.ts
@@ -4,4 +4,5 @@ export interface RetsObject {
   contentId: string
   contentType: string
   description: string
+  location: string
 }

--- a/src/utils/readRetsObject.ts
+++ b/src/utils/readRetsObject.ts
@@ -28,10 +28,11 @@ export const readRetsObject = (buffer: Buffer): RetsObject | undefined => {
   const data = Buffer.concat(rest)
   const parsedHeader = readRetsHeaders(header)
 
-  const contentId = parsedHeader['Content-ID'] ? parsedHeader['Content-ID'] : ''
-  const objectId = parsedHeader['Object-ID'] ? parseInt(parsedHeader['Object-ID'], 10) : 1
-  const contentType = parsedHeader['Content-Type'] ? parsedHeader['Content-Type'] : ''
-  const description = parsedHeader.Description ? parsedHeader.Description : ''
+  const contentId = parsedHeader['Content-ID'] ?? ''
+  const objectId = parseInt(parsedHeader['Object-ID'], 10) || 1
+  const contentType = parsedHeader['Content-Type'] ?? ''
+  const description = parsedHeader.Description ?? ''
+  const location = parsedHeader.Location ?? ''
 
   return {
     data,
@@ -39,5 +40,6 @@ export const readRetsObject = (buffer: Buffer): RetsObject | undefined => {
     objectId,
     contentType,
     description,
+    location,
   }
 }


### PR DESCRIPTION
### Issue:
REBGV (Real Estate Board of Greater Vancouver) returns a `Content-Type` header of `multipart/parallel; boundary=rets.object.content.boundary.1721839732723`, where there is no trailing `;`. This causes `boundaryMatches` to be `undefined`, resulting in the following error:
```
ERROR: TypeError: Cannot read properties of null (reading 'length')
```
### Fix:
This PR adds a check to ensure that `boundaryMatches?.[1]` exists before it is used. This prevents the error from being thrown when the boundary is not properly matched in the `Content-Type` header.

### Test:
Local testing has been performed, and the fix passed successfully.
